### PR TITLE
加入快速版的 CI-test

### DIFF
--- a/.github/workflows/ci-cmake.yml
+++ b/.github/workflows/ci-cmake.yml
@@ -30,7 +30,7 @@ jobs:
       run: |
         if [ "${{ github.event_name }}" = "push" ]; then
           echo "Push -> build only"
-          cmake -B ${{github.workspace}} -S engine -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
+          cmake -B ${{github.workspace}}/build -S engine -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
         else
           echo "Merge -> full test"
           cmake -B ${{github.workspace}}/build -S engine \


### PR DESCRIPTION
每次 push 時會測試 bulid，只有在 PR merge 時才有完整的測試，合理分配測試時間。

Closes #8