### PR TITLE
Add PV Move Ordering and Single PV Lines with +0 elo gain

### DIFF
--- a/engine/include/move/Move.h
+++ b/engine/include/move/Move.h
@@ -4,6 +4,7 @@
 #include "board/Board.h"
 #include "board/Piece.h"
 #include "debug/log.h"
+#include "pgn/Pgn_Transformer.h"
 
 enum Castle
 {
@@ -192,6 +193,26 @@ inline Move bitMovetoOriMove(const Board& board, const BitMove& move)
             res.castle = SHORT_CASTLE;
         else if (res.to.col == 2)
             res.castle = LONG_CASTLE;
+    }
+
+    return res;
+}
+
+inline std::string bitMoveToUCIMove(const BitMove& move)
+{
+    if (move == INVALID_BITMOVE)
+    {
+        return "INVALID_BITMOVE";
+    }
+
+    Position from = squareToPosition(getFromSquare(move));
+    Position to = squareToPosition(getToSquare(move));
+
+    std::string res = positionToPgn(from) + positionToPgn(to);
+
+    if (getPromotion(move))
+    {
+        res += std::tolower(pieceToChar(getPromotePiece(move)));
     }
 
     return res;

--- a/engine/include/move/Move_Order.h
+++ b/engine/include/move/Move_Order.h
@@ -11,6 +11,7 @@ struct ScoreMove
 
 struct advanceMoves
 {
+    BitMove PVMove;
     BitMove TTMove;
 };
 

--- a/engine/include/search/PV_Table.h
+++ b/engine/include/search/PV_Table.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include "Type.h"
+#include "debug/log.h"
+#include "search/Search_Variables.h"
+
+struct PVTable
+{
+    BitMove table[SearchVarialble::MAX_PLY][SearchVarialble::MAX_PLY];
+    int length[SearchVarialble::MAX_PLY] = {}; // init to 0.
+
+    inline void clearLine(int ply)
+    {
+        ENGINE_ASSERT(ply < SearchVarialble::MAX_PLY);
+        length[ply] = 0;
+    }
+
+    inline void update(int ply, const BitMove move)
+    {
+        table[ply][0] = move;
+
+        for (int i = 0; i < length[ply + 1]; i++)
+        {
+            table[ply][i + 1] = table[ply + 1][i];
+        }
+
+        length[ply] = length[ply + 1] + 1;
+    }
+};

--- a/engine/include/search/Search.h
+++ b/engine/include/search/Search.h
@@ -14,6 +14,7 @@ struct SearchResult
     bool isValid = 0;
     Move bestMove;
     int bestScore;
+    BitMove bestBitMove = INVALID_BITMOVE;
 };
 
 struct SearchLimits
@@ -36,7 +37,7 @@ public:
 private:
     Evaluate eval;
 
-    SearchResult chooseMove(Board& board, int depth, int alpha, int beta, int ply);
+    SearchResult chooseMove(Board& board, int depth, int alpha, int beta, int ply, const BitMove PVMove);
 
     int negamax(Board& board, int depth, int alpha, int beta, int ply);
 

--- a/engine/include/search/Search.h
+++ b/engine/include/search/Search.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "PV_Table.h"
 #include "board/Board.h"
 #include "evaluate/Evaluate.h"
 #include "move/Move.h"
@@ -26,6 +27,7 @@ struct SearchLimits
 struct SearchInfo
 {
     int64_t depth, score, nodes, qsnodes, timeMs, nps;
+    PVTable pv;
 };
 
 class Search
@@ -54,6 +56,8 @@ private:
         uint64_t qsNodes = 0;
 
         std::chrono::steady_clock::time_point startTime;
+
+        PVTable pv, prevPv;
     } state;
 
     bool shouldStop();

--- a/engine/include/search/Search.h
+++ b/engine/include/search/Search.h
@@ -39,7 +39,8 @@ public:
 private:
     Evaluate eval;
 
-    SearchResult chooseMove(Board& board, int depth, int alpha, int beta, int ply, const BitMove PVMove);
+    SearchResult
+    chooseMove(Board& board, int depth, int alpha, int beta, int ply, const BitMove PVMove);
 
     int negamax(Board& board, int depth, int alpha, int beta, int ply);
 

--- a/engine/include/search/Search_Variables.h
+++ b/engine/include/search/Search_Variables.h
@@ -2,5 +2,6 @@
 
 namespace SearchVarialble
 {
-constexpr int MAX_SEARCH_DEPTH = 10;
+constexpr int MAX_SEARCH_DEPTH = 128;
+constexpr int MAX_PLY = 128;
 } // namespace SearchVarialble

--- a/engine/src/move/Move_Order.cpp
+++ b/engine/src/move/Move_Order.cpp
@@ -8,8 +8,8 @@
 
 #include <algorithm>
 
-const int PVMOVE_SCORE = 600000;
-const int TT_SCORE = 500000;
+const int TT_SCORE = 600000;
+const int PVMOVE_SCORE = 500000;
 const int PROMOTION_SCORE = 400000;
 const int CAPTURE_SCORE = 300000;
 const int KILLER_1_SCORE = 200000;

--- a/engine/src/move/Move_Order.cpp
+++ b/engine/src/move/Move_Order.cpp
@@ -3,23 +3,26 @@
 #pragma GCC optimize("O3,unroll-loops")
 
 #include "evaluate/Material_Point.h"
-#include "evaluate/SEE.h"
 #include "move/Make_BitMove.h"
 #include "move/Move_Order.h"
 
 #include <algorithm>
 
-const int TT_SCORE = 1000000;
-const int CAPTURE_SCORE = 500000;
-const int KILLER_1_SCORE = 400000;
-const int KILLER_2_SCORE = 300000;
-const int PROMOTION_SCORE = 750000;
+const int PVMOVE_SCORE = 600000;
+const int TT_SCORE = 500000;
+const int PROMOTION_SCORE = 400000;
+const int CAPTURE_SCORE = 300000;
+const int KILLER_1_SCORE = 200000;
+const int KILLER_2_SCORE = 100000;
 
 int evaluateMoveScore(const Board& board, const BitMove move, const advanceMoves& adv)
 {
     MoveState state(board, move);
 
     int score = 0;
+
+    if (adv.PVMove == move)
+        score += PVMOVE_SCORE;
 
     if (adv.TTMove == move)
         score += TT_SCORE;

--- a/engine/src/search/Search.cpp
+++ b/engine/src/search/Search.cpp
@@ -10,7 +10,6 @@
 #include "search/Search_Variables.h"
 #include "search/TT.h"
 #include <chrono>
-#include <iterator>
 
 void printInfo(const SearchInfo& info)
 {
@@ -196,6 +195,9 @@ int Search::negamax(Board& board, int depth, int alpha, int beta, int ply)
 {
     state.negamaxNodes++;
 
+    // Clear current PV line
+    state.pv.clearLine(ply);
+
     // Probe TT table.
     TTEntry ttOut;
     int ttScore = -MAX_SCORE;
@@ -223,9 +225,6 @@ int Search::negamax(Board& board, int depth, int alpha, int beta, int ply)
         if (shouldStop())
             return TIMEOUT_SCORE;
     }
-
-    // Clear current PV line
-    state.pv.clearLine(ply);
 
     // depth = 0 -> qs search
     if (depth == 0)

--- a/engine/src/search/Search.cpp
+++ b/engine/src/search/Search.cpp
@@ -10,6 +10,7 @@
 #include "search/Search_Variables.h"
 #include "search/TT.h"
 #include <chrono>
+#include <iterator>
 
 void printInfo(const SearchInfo& info)
 {
@@ -30,7 +31,16 @@ void printInfo(const SearchInfo& info)
         std::cout << " score cp " << info.score;
     }
 
-    std::cout << " nodes " << info.nodes << " nps " << info.nps << " time " << info.timeMs << '\n';
+    std::cout << " nodes " << info.nodes << " nps " << info.nps << " time " << info.timeMs;
+
+    std::cout << " pv ";
+    int pvLength = info.pv.length[0];
+    for (int i = 0; i < pvLength; i++)
+    {
+        std::cout << bitMoveToUCIMove(info.pv.table[0][i]) << ' ';
+    }
+
+    std::cout << '\n';
 }
 
 bool Search::shouldStop()
@@ -72,7 +82,7 @@ SearchResult Search::findBestMove(const Board& board)
     Board copyBoard = board;
 
     // current result is invalid
-    SearchResult result = {false, inValidMove, -MAX_SCORE};
+    SearchResult result = {false, inValidMove, -MAX_SCORE, INVALID_BITMOVE};
 
     // At least output a valid move
     BitMove rootMoves[256];
@@ -102,6 +112,7 @@ SearchResult Search::findBestMove(const Board& board)
         {
             result = currentResult;
             lastBestMove = result.bestBitMove;
+            state.prevPv = state.pv;
         }
 
         // print info
@@ -115,6 +126,7 @@ SearchResult Search::findBestMove(const Board& board)
         info.timeMs =
             std::chrono::duration_cast<std::chrono::milliseconds>(now - state.startTime).count();
         info.nps = (info.timeMs > 0 ? info.nodes * 1000 / info.timeMs : 0);
+        info.pv = state.pv;
 
         printInfo(info);
     }
@@ -126,12 +138,20 @@ SearchResult Search::chooseMove(Board& board, int depth, int alpha, int beta, in
 {
     SearchResult result = {false, inValidMove, -MAX_SCORE};
 
+    // Clear currecnt PV line
+    state.pv.clearLine(ply);
+
     // generate all moves
     BitMove moves[256];
     int nMoves = generateAllLegalMoves(board, moves);
 
+    // Get last PV move
+    BitMove pvMove = INVALID_BITMOVE;
+    if (state.prevPv.length[ply] > 0)
+        pvMove = state.prevPv.table[ply][0];
+
     // sort moves
-    sortMove(board, moves, nMoves, {PVMove, INVALID_BITMOVE});
+    sortMove(board, moves, nMoves, {pvMove, INVALID_BITMOVE});
 
     for (int i = 0; i < nMoves; i++)
     {
@@ -150,7 +170,7 @@ SearchResult Search::chooseMove(Board& board, int depth, int alpha, int beta, in
         undoBitMove(board, move, undo);
 
         Move oriMove = bitMovetoOriMove(board, move);
-        std::cout << oriMove << " | " << score << '\n';
+        // std::cout << oriMove << " | " << score << '\n';
 
         if (score == -TIMEOUT_SCORE)
             return {false, inValidMove, -MAX_SCORE, INVALID_BITMOVE};
@@ -163,7 +183,10 @@ SearchResult Search::chooseMove(Board& board, int depth, int alpha, int beta, in
             result.bestBitMove = move;
         }
         if (score > alpha)
+        {
             alpha = score;
+            state.pv.update(ply, move);
+        }
     }
 
     return result;
@@ -176,7 +199,7 @@ int Search::negamax(Board& board, int depth, int alpha, int beta, int ply)
     // Probe TT table.
     TTEntry ttOut;
     int ttScore = -MAX_SCORE;
-    BitMove ttMove;
+    BitMove ttMove = INVALID_BITMOVE;
     if (probeTT(board.zobristKey, depth, alpha, beta, ply, ttOut, ttScore, ttMove) == true)
     {
         return ttScore;
@@ -201,6 +224,9 @@ int Search::negamax(Board& board, int depth, int alpha, int beta, int ply)
             return TIMEOUT_SCORE;
     }
 
+    // Clear current PV line
+    state.pv.clearLine(ply);
+
     // depth = 0 -> qs search
     if (depth == 0)
     {
@@ -211,8 +237,13 @@ int Search::negamax(Board& board, int depth, int alpha, int beta, int ply)
     BitMove moves[256];
     int nMoves = generateAllLegalMoves(board, moves);
 
+    // Get last PV move.
+    BitMove pvMove = INVALID_BITMOVE;
+    if (state.prevPv.length[ply] > 0)
+        pvMove = state.prevPv.table[ply][0];
+
     // Sort moves.
-    sortMove(board, moves, nMoves, {INVALID_BITMOVE, ttMove});
+    sortMove(board, moves, nMoves, {pvMove, ttMove});
 
     // check checkmate / stalemate
     if (nMoves == 0)
@@ -250,7 +281,12 @@ int Search::negamax(Board& board, int depth, int alpha, int beta, int ply)
             hasMove = true;
         }
         if (score > alpha)
+        {
             alpha = score;
+
+            // Update PV line
+            state.pv.update(ply, move);
+        }
 
         if (alpha >= beta)
             break;

--- a/engine/src/search/Search.cpp
+++ b/engine/src/search/Search.cpp
@@ -96,7 +96,6 @@ SearchResult Search::findBestMove(const Board& board)
     // set max depth.
     int maxDepth = limits.maxDepth == -1 ? SearchVarialble::MAX_SEARCH_DEPTH : limits.maxDepth;
 
-
     BitMove lastBestMove = INVALID_BITMOVE;
     // iterative deepening
     for (int depth = 1; depth <= maxDepth; depth++)
@@ -105,7 +104,8 @@ SearchResult Search::findBestMove(const Board& board)
         if (shouldStop())
             break;
 
-        SearchResult currentResult = chooseMove(copyBoard, depth, -MAX_SCORE, MAX_SCORE, 0, lastBestMove);
+        SearchResult currentResult =
+            chooseMove(copyBoard, depth, -MAX_SCORE, MAX_SCORE, 0, lastBestMove);
 
         if (currentResult.isValid)
         {
@@ -133,7 +133,8 @@ SearchResult Search::findBestMove(const Board& board)
     return result;
 }
 
-SearchResult Search::chooseMove(Board& board, int depth, int alpha, int beta, int ply, const BitMove PVMove)
+SearchResult
+Search::chooseMove(Board& board, int depth, int alpha, int beta, int ply, const BitMove PVMove)
 {
     SearchResult result = {false, inValidMove, -MAX_SCORE};
 

--- a/engine/src/search/Search.cpp
+++ b/engine/src/search/Search.cpp
@@ -87,6 +87,8 @@ SearchResult Search::findBestMove(const Board& board)
     // set max depth.
     int maxDepth = limits.maxDepth == -1 ? SearchVarialble::MAX_SEARCH_DEPTH : limits.maxDepth;
 
+
+    BitMove lastBestMove = INVALID_BITMOVE;
     // iterative deepening
     for (int depth = 1; depth <= maxDepth; depth++)
     {
@@ -94,11 +96,12 @@ SearchResult Search::findBestMove(const Board& board)
         if (shouldStop())
             break;
 
-        SearchResult currentResult = chooseMove(copyBoard, depth, -MAX_SCORE, MAX_SCORE, 0);
+        SearchResult currentResult = chooseMove(copyBoard, depth, -MAX_SCORE, MAX_SCORE, 0, lastBestMove);
 
         if (currentResult.isValid)
         {
             result = currentResult;
+            lastBestMove = result.bestBitMove;
         }
 
         // print info
@@ -119,7 +122,7 @@ SearchResult Search::findBestMove(const Board& board)
     return result;
 }
 
-SearchResult Search::chooseMove(Board& board, int depth, int alpha, int beta, int ply)
+SearchResult Search::chooseMove(Board& board, int depth, int alpha, int beta, int ply, const BitMove PVMove)
 {
     SearchResult result = {false, inValidMove, -MAX_SCORE};
 
@@ -128,13 +131,13 @@ SearchResult Search::chooseMove(Board& board, int depth, int alpha, int beta, in
     int nMoves = generateAllLegalMoves(board, moves);
 
     // sort moves
-    sortMove(board, moves, nMoves, {INVALID_BITMOVE});
+    sortMove(board, moves, nMoves, {PVMove, INVALID_BITMOVE});
 
     for (int i = 0; i < nMoves; i++)
     {
         // time check.
         if (shouldStop())
-            return {false, inValidMove, -MAX_SCORE};
+            return {false, inValidMove, -MAX_SCORE, INVALID_BITMOVE};
 
         BitMove move = moves[i];
 
@@ -150,13 +153,14 @@ SearchResult Search::chooseMove(Board& board, int depth, int alpha, int beta, in
         std::cout << oriMove << " | " << score << '\n';
 
         if (score == -TIMEOUT_SCORE)
-            return {false, inValidMove, -MAX_SCORE};
+            return {false, inValidMove, -MAX_SCORE, INVALID_BITMOVE};
 
         if (score > result.bestScore)
         {
             result.isValid = true;
             result.bestMove = bitMovetoOriMove(board, move);
             result.bestScore = score;
+            result.bestBitMove = move;
         }
         if (score > alpha)
             alpha = score;
@@ -208,7 +212,7 @@ int Search::negamax(Board& board, int depth, int alpha, int beta, int ply)
     int nMoves = generateAllLegalMoves(board, moves);
 
     // Sort moves.
-    sortMove(board, moves, nMoves, {ttMove});
+    sortMove(board, moves, nMoves, {INVALID_BITMOVE, ttMove});
 
     // check checkmate / stalemate
     if (nMoves == 0)
@@ -295,7 +299,7 @@ int Search::quietscence(Board& board, int alpha, int beta, int ply)
     int nCaptureMoves = generateLegalCaptureMoves(board, captureMoves);
 
     // Sort moves.
-    sortMove(board, captureMoves, nCaptureMoves, {INVALID_BITMOVE});
+    sortMove(board, captureMoves, nCaptureMoves, {INVALID_BITMOVE, INVALID_BITMOVE});
 
     if (nCaptureMoves == 0)
     {


### PR DESCRIPTION
- Add PV move ordering to make searching faster.
- Add PV lines for future feature.
- [Github Action with +0 elo gain](https://github.com/emmetthor/Hynobius/actions/runs/24297648450/job/70945302256)

Closes #53 