### PR TITLE
Add QS Search Check Evasion with 22.6 +/- 40.9 Elo Gain

### DIFF
--- a/engine/include/search/Search_Variables.h
+++ b/engine/include/search/Search_Variables.h
@@ -2,7 +2,7 @@
 
 namespace SearchVarialble
 {
-constexpr int MAX_SEARCH_DEPTH = 128;
-constexpr int MAX_PLY = 128;
+constexpr int MAX_SEARCH_DEPTH = 20;
+constexpr int MAX_PLY = 20;
 constexpr int MAX_GAME_PLY = 2048;
 } // namespace SearchVarialble

--- a/engine/src/search/Search.cpp
+++ b/engine/src/search/Search.cpp
@@ -417,7 +417,8 @@ int Search::quietscence(Board& board, int alpha, int beta, int ply)
 
     if (ply > SearchVarialble::MAX_PLY)
     {
-        return (board.player == Player::WHITE ? 1 : -1)  * eval.evaluateBoard(board, EVALUATE_MODE::FULL);
+        return (board.player == Player::WHITE ? 1 : -1) *
+               eval.evaluateBoard(board, EVALUATE_MODE::FULL);
     }
 
     BitMove moves[256];
@@ -434,8 +435,8 @@ int Search::quietscence(Board& board, int alpha, int beta, int ply)
     }
     else
     {
-        int standerdPoint =
-            (board.player == Player::WHITE ? 1 : -1) * eval.evaluateBoard(board, EVALUATE_MODE::FULL);
+        int standerdPoint = (board.player == Player::WHITE ? 1 : -1) *
+                            eval.evaluateBoard(board, EVALUATE_MODE::FULL);
         if (standerdPoint >= beta)
             return standerdPoint;
         if (standerdPoint > alpha)

--- a/engine/src/search/Search.cpp
+++ b/engine/src/search/Search.cpp
@@ -415,15 +415,39 @@ int Search::quietscence(Board& board, int alpha, int beta, int ply)
             return TIMEOUT_SCORE;
     }
 
-    int standerdPoint =
-        (board.player == Player::WHITE ? 1 : -1) * eval.evaluateBoard(board, EVALUATE_MODE::FULL);
-    if (standerdPoint >= beta)
-        return standerdPoint;
-    if (standerdPoint > alpha)
-        alpha = standerdPoint;
+    if (ply > SearchVarialble::MAX_PLY)
+    {
+        return (board.player == Player::WHITE ? 1 : -1)  * eval.evaluateBoard(board, EVALUATE_MODE::FULL);
+    }
 
-    BitMove captureMoves[256];
-    int nCaptureMoves = generateLegalCaptureMoves(board, captureMoves);
+    BitMove moves[256];
+    int nMoves = -1;
+
+    if (isInCheck(board, board.player))
+    {
+        nMoves = generateAllLegalMoves(board, moves);
+
+        if (nMoves == 0)
+        {
+            return -MATE_SCORE + ply;
+        }
+    }
+    else
+    {
+        int standerdPoint =
+            (board.player == Player::WHITE ? 1 : -1) * eval.evaluateBoard(board, EVALUATE_MODE::FULL);
+        if (standerdPoint >= beta)
+            return standerdPoint;
+        if (standerdPoint > alpha)
+            alpha = standerdPoint;
+
+        nMoves = generateLegalCaptureMoves(board, moves);
+
+        if (nMoves == 0)
+        {
+            return alpha;
+        }
+    }
 
     // Sort moves.
     advanceMoves adv = {
@@ -432,16 +456,11 @@ int Search::quietscence(Board& board, int alpha, int beta, int ply)
         INVALID_BITMOVE,
         INVALID_BITMOVE,
     };
-    sortMove(board, captureMoves, nCaptureMoves, adv);
+    sortMove(board, moves, nMoves, adv);
 
-    if (nCaptureMoves == 0)
+    for (int i = 0; i < nMoves; i++)
     {
-        return alpha;
-    }
-
-    for (int i = 0; i < nCaptureMoves; i++)
-    {
-        BitMove move = captureMoves[i];
+        BitMove move = moves[i];
 
         UndoState undo;
 


### PR DESCRIPTION
- Add check evasion to decrease blunders.
- [GitHub action with 22.6 +/- 40.9 elo gain](https://github.com/Hynobius-Chess/Hynobius-testing/actions/runs/24727685660).

closes #65 