### PR TITLE
Improve Time Management and Fix `TIMEOUT_SCORE` Transferation Problems.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,3 +90,8 @@
     set_target_properties(test-bitmove PROPERTIES WIN32_EXECUTABLE OFF)
 
     add_test(NAME BitMoveTest COMMAND test-bitmove)
+
+    # link must-have dlls
+    if (MINGW)
+        target_link_options(Hynobius PRIVATE -static -static-libgcc -static-libstdc++)
+    endif()

--- a/engine/include/Time_Management.h
+++ b/engine/include/Time_Management.h
@@ -5,7 +5,7 @@
 
 constexpr int64_t MAX_THINK_TIME = INT64_MAX;
 constexpr int64_t MIN_THINK_TIME = 10;
-constexpr int64_t MOVE_OVERHEAD = 50;
+constexpr int64_t MOVE_OVERHEAD = 200;
 
 struct TimeManage
 {

--- a/engine/include/Time_Management.h
+++ b/engine/include/Time_Management.h
@@ -4,6 +4,8 @@
 #include <cstdint>
 
 constexpr int64_t MAX_THINK_TIME = INT64_MAX;
+constexpr int64_t MIN_THINK_TIME = 10;
+constexpr int64_t MOVE_OVERHEAD = 50;
 
 struct TimeManage
 {

--- a/engine/src/Time_Management.cpp
+++ b/engine/src/Time_Management.cpp
@@ -18,7 +18,8 @@ int64_t timeManageCore(int64_t timeLeft, int64_t increment)
     }
 
     // normal
-    else {
+    else
+    {
         return safeTime / 30 + increment * 3 / 4;
     }
 }

--- a/engine/src/Time_Management.cpp
+++ b/engine/src/Time_Management.cpp
@@ -1,8 +1,26 @@
 #include "Time_Management.h"
+#include <algorithm>
 
 int64_t timeManageCore(int64_t timeLeft, int64_t increment)
 {
-    return timeLeft / 30 + increment;
+    int64_t safeTime = std::max<int64_t>(0, timeLeft - MOVE_OVERHEAD);
+
+    // 0.2 seconds
+    if (safeTime <= 200)
+    {
+        return std::max<int64_t>(MIN_THINK_TIME, increment / 2);
+    }
+
+    // 1 seconds
+    else if (safeTime <= 1000)
+    {
+        return std::max<int64_t>(safeTime / 8, increment);
+    }
+
+    // normal
+    else {
+        return safeTime / 30 + increment * 3 / 4;
+    }
 }
 
 SearchLimits timeManager(const TimeManage& tm, Player player)

--- a/engine/src/Time_Management.cpp
+++ b/engine/src/Time_Management.cpp
@@ -6,15 +6,15 @@ int64_t timeManageCore(int64_t timeLeft, int64_t increment)
     int64_t safeTime = std::max<int64_t>(0, timeLeft - MOVE_OVERHEAD);
 
     // 0.2 seconds
-    if (safeTime <= 200)
+    if (safeTime <= std::max<int64_t>(2 * increment, 1000))
     {
-        return std::max<int64_t>(MIN_THINK_TIME, increment / 2);
+        return std::max<int64_t>(MIN_THINK_TIME, increment / 4);
     }
 
-    // 1 seconds
-    else if (safeTime <= 1000)
+    // 10 seconds
+    else if (safeTime <= std::max<int64_t>(8 * increment, 5000))
     {
-        return std::max<int64_t>(safeTime / 8, increment);
+        return std::max<int64_t>(safeTime / 15, increment / 2);
     }
 
     // normal

--- a/engine/src/search/Search.cpp
+++ b/engine/src/search/Search.cpp
@@ -47,6 +47,20 @@ bool Search::shouldStop()
     if (state.stopped)
         return true;
 
+    int interval = 2;
+    if (limits.maxTimeMs <= 50)
+        interval = 16;
+    else if (limits.maxTimeMs <= 100)
+        interval = 32;
+    else if (limits.maxTimeMs <= 500)
+        interval = 64;
+    else if (limits.maxTimeMs <= 2500)
+        interval = 128;
+    else
+        interval = 1024;
+
+    if (((state.negamaxNodes + state.qsNodes) & (interval - 1)) != 0) return false;
+
     if (limits.maxTimeMs != -1)
     {
         auto now = std::chrono::steady_clock::now();
@@ -123,8 +137,10 @@ SearchResult Search::findBestMove(const Board& board)
 
                 currentResult = chooseMove(copyBoard, depth, alpha, beta, 0, lastBestMove);
 
-                if (!currentResult.isValid)
+                if (!currentResult.isValid) {
+                    copyBoard.popRepetitionKey();
                     return result;
+                }
 
                 if (currentResult.bestScore <= alpha)
                 {
@@ -197,7 +213,6 @@ Search::chooseMove(Board& board, int depth, int alpha, int beta, int ply, const 
         // time check.
         if (shouldStop())
         {
-            board.popRepetitionKey();
             return {false, inValidMove, -MAX_SCORE, INVALID_BITMOVE};
         }
 
@@ -218,7 +233,6 @@ Search::chooseMove(Board& board, int depth, int alpha, int beta, int ply, const 
 
         if (score == -TIMEOUT_SCORE)
         {
-            board.popRepetitionKey();
             return {false, inValidMove, -MAX_SCORE, INVALID_BITMOVE};
         }
         if (score > result.bestScore)
@@ -265,17 +279,8 @@ int Search::negamax(Board& board, int depth, int alpha, int beta, int ply)
     BitMove bestMove = INVALID_BITMOVE;
     bool hasMove = false;
 
-    // time check.
-    if ((state.negamaxNodes + state.qsNodes) & 2047)
-    {
-        // continue searching
-    }
-    else
-    {
-        // check time
-        if (shouldStop())
-            return TIMEOUT_SCORE;
-    }
+    if (shouldStop())
+        return TIMEOUT_SCORE;
 
     // depth = 0 -> qs search
     if (depth == 0)
@@ -341,7 +346,7 @@ int Search::negamax(Board& board, int depth, int alpha, int beta, int ply)
 
             // Using null-window to limit score window -> faster.
             score = -negamax(board, searchDepth, -alpha - 1, -alpha, ply + 1);
-            if (score > alpha)
+            if (score != -TIMEOUT_SCORE && score > alpha)
             {
                 // fail high -> research with full depth.
                 score = -negamax(board, depth - 1, -beta, -alpha, ply + 1);
@@ -403,17 +408,8 @@ int Search::quietscence(Board& board, int alpha, int beta, int ply)
 {
     state.qsNodes++;
 
-    // time check.
-    if ((state.negamaxNodes + state.qsNodes) & 2047)
-    {
-        // continue searching
-    }
-    else
-    {
-        // check
-        if (shouldStop())
-            return TIMEOUT_SCORE;
-    }
+    if (shouldStop())
+        return TIMEOUT_SCORE;
 
     if (ply > SearchVarialble::MAX_PLY)
     {
@@ -461,6 +457,10 @@ int Search::quietscence(Board& board, int alpha, int beta, int ply)
 
     for (int i = 0; i < nMoves; i++)
     {
+        // time check.
+        if (shouldStop())
+            return TIMEOUT_SCORE;
+            
         BitMove move = moves[i];
 
         UndoState undo;

--- a/engine/src/search/Search.cpp
+++ b/engine/src/search/Search.cpp
@@ -59,7 +59,8 @@ bool Search::shouldStop()
     else
         interval = 1024;
 
-    if (((state.negamaxNodes + state.qsNodes) & (interval - 1)) != 0) return false;
+    if (((state.negamaxNodes + state.qsNodes) & (interval - 1)) != 0)
+        return false;
 
     if (limits.maxTimeMs != -1)
     {
@@ -137,7 +138,8 @@ SearchResult Search::findBestMove(const Board& board)
 
                 currentResult = chooseMove(copyBoard, depth, alpha, beta, 0, lastBestMove);
 
-                if (!currentResult.isValid) {
+                if (!currentResult.isValid)
+                {
                     copyBoard.popRepetitionKey();
                     return result;
                 }
@@ -460,7 +462,7 @@ int Search::quietscence(Board& board, int alpha, int beta, int ply)
         // time check.
         if (shouldStop())
             return TIMEOUT_SCORE;
-            
+
         BitMove move = moves[i];
 
         UndoState undo;


### PR DESCRIPTION
- Add low time manage.
- Check time more frequent based on how much time the engine has.
- Fix some bugs when Trasfering `TIMEOUT_SCORE`.

closes #67