### PR TITLE
Refactor Move Ordering With 49.0 +/- 41.2 Elo Gain

### DIFF
--- a/engine/include/move/Make_BitMove.h
+++ b/engine/include/move/Make_BitMove.h
@@ -4,6 +4,39 @@
 #include <board/Piece.h>
 #include <cstdint>
 
+inline Piece getCapturePiece(const Board& board, const BitMove move)
+{
+    if (!getCapture(move))
+        return Piece::EMPTY;
+
+    Position from = squareToPosition(getFromSquare(move));
+    Position to = squareToPosition(getToSquare(move));
+    Piece res;
+    if (getEnPassant(move))
+    {
+        Position capturePos = {from.row, to.col};
+        res = board.at(capturePos);
+
+        ENGINE_ASSERT(res == makePiece(opponent(board.player), 'P'));
+    }
+    else
+    {
+        res = board.at(to);
+    }
+
+    return res;
+}
+
+inline Piece getMovePiece(const Board& board, const BitMove move)
+{
+    Position from = squareToPosition(getFromSquare(move));
+    Piece movePiece = board.at(from);
+
+    ENGINE_ASSERT(isValidPieceIndex(pieceToIndex(movePiece)));
+
+    return movePiece;
+}
+
 // intergret move infos
 // placedPiece: The piece that actually placed at Position to
 struct MoveState
@@ -24,17 +57,7 @@ struct MoveState
         to = squareToPosition(getToSquare(move));
 
         movePiece = board.at(from);
-        if (getEnPassant(move))
-        {
-            Position capturePos = {from.row, to.col};
-            capturedPiece = board.at(capturePos);
-
-            ENGINE_ASSERT(capturedPiece == makePiece(opponent(board.player), 'P'));
-        }
-        else
-        {
-            capturedPiece = board.at(to);
-        }
+        capturedPiece = getCapturePiece(board, move);
 
         isCastle = getCastle(move);
         isPromotion = getPromotion(move);

--- a/engine/src/move/Move_Order.cpp
+++ b/engine/src/move/Move_Order.cpp
@@ -17,15 +17,13 @@ const int KILLER_2_SCORE = 100000;
 
 int evaluateMoveScore(const Board& board, const BitMove move, const advanceMoves& adv)
 {
-    MoveState state(board, move);
-
     int score = 0;
 
     if (adv.PVMove == move)
-        score += PVMOVE_SCORE;
+        return PVMOVE_SCORE;
 
     if (adv.TTMove == move)
-        score += TT_SCORE;
+        return TT_SCORE;
 
     if (adv.killerMove1 == move)
         score += KILLER_1_SCORE;
@@ -33,17 +31,22 @@ int evaluateMoveScore(const Board& board, const BitMove move, const advanceMoves
     if (adv.killerMove2 == move)
         score += KILLER_2_SCORE;
 
-    if (state.isPromotion)
+    if (getPromotion(move))
     {
         // 最先看
         score += PROMOTION_SCORE;
         score += pieceValue(getPromotePiece(move));
     }
 
-    if (state.capturedPiece != Piece::EMPTY)
+    if (getCapture(move))
     {
-        score += CAPTURE_SCORE;
-        score += pieceValue(state.capturedPiece) * 100 - pieceValue(state.capturedPiece);
+        Piece capturePiece = getCapturePiece(board, move);
+        Piece movePiece = getMovePiece(board, move);
+        if (capturePiece != Piece::EMPTY)
+        {
+            score += CAPTURE_SCORE;
+            score += pieceValue(capturePiece) * 100 - pieceValue(movePiece);
+        }
     }
 
     return score;

--- a/engine/src/move/Move_Order.cpp
+++ b/engine/src/move/Move_Order.cpp
@@ -1,11 +1,9 @@
-#include "move/Make_BitMove.h"
-#include "move/Move.h"
 #pragma GCC optimize("O3,unroll-loops")
 
+#include "move/Move_Order.h"
 #include "evaluate/Material_Point.h"
 #include "move/Make_BitMove.h"
-#include "move/Move_Order.h"
-
+#include "move/Move.h"
 #include <algorithm>
 
 const int TT_SCORE = 600000;


### PR DESCRIPTION
- Remove `MoveState`.
- Add tools to make `getCapturePiece` and `getMovePiece` faster.
- FIx MVV-LVA bug.
- Return `TT_SCORE` and `PV_SCORE` instead of adding these scores together.
- [GitHub action with 49.0 +/- 41.2 elo gain](https://github.com/Hynobius-Chess/Hynobius-testing/actions/runs/24950311941)

closes #69 