### PR TITLE
Fix Some Elo Regressions by Adjusting Search Initializations

### DIFF
--- a/engine/include/search/Search.h
+++ b/engine/include/search/Search.h
@@ -116,6 +116,7 @@ struct SearchContext
         startTime = std::chrono::steady_clock::now();
         pv = PVTable{};
         prevPv = PVTable{};
+        prevScore = 0;
         stats.clear();
     }
 };

--- a/engine/include/search/Search.h
+++ b/engine/include/search/Search.h
@@ -9,6 +9,7 @@
 #include "move/Make_BitMove.h"
 #include "move/Move.h"
 #include "move/Move_Order.h"
+#include "search/PV_Table.h"
 #include <chrono>
 
 constexpr int MATE_SCORE = 30000;
@@ -104,10 +105,6 @@ struct SearchContext
 
     PVTable pv, prevPv;
 
-    killerMove kill;
-
-    HistoryHeuristic history;
-
     int prevScore = 0;
 
     SearchStats stats;
@@ -117,6 +114,8 @@ struct SearchContext
         stopped = false;
         timeout = false;
         startTime = std::chrono::steady_clock::now();
+        pv = PVTable{};
+        prevPv = PVTable{};
         stats.clear();
     }
 };
@@ -144,6 +143,9 @@ private:
     void printInfo();
 
     SearchLimits limits;
+
+    killerMove kill;
+    HistoryHeuristic history;
 
     SearchContext state;
 

--- a/engine/src/search/Search.cpp
+++ b/engine/src/search/Search.cpp
@@ -9,6 +9,8 @@
 #include "move/Make_BitMove.h"
 #include "move/Move.h"
 #include "move/Move_Order.h"
+#include "search/History_Heuristic.h"
+#include "search/Killer_Move.h"
 #include "search/Search_Variables.h"
 #include "search/TT.h"
 #include <chrono>
@@ -146,6 +148,10 @@ SearchResult Search::findBestMove(const Board& board)
     // init state.
     state.reset();
 
+    // clear killer and history move to recover from v0.3.0-beta.2
+    kill = killerMove{};
+    history = HistoryHeuristic{};
+
     // make copyBoard non-const.
     Board copyBoard = board;
 
@@ -200,7 +206,6 @@ SearchResult Search::findBestMove(const Board& board)
         SearchResult currentResult;
         currentResult.clear();
         currentResult = {false, -MAX_SCORE, INVALID_BITMOVE};
-        ;
 
         if (depth == 1)
         {

--- a/engine/src/search/Search.cpp
+++ b/engine/src/search/Search.cpp
@@ -299,8 +299,7 @@ Search::chooseMove(Board& board, int depth, int alpha, int beta, int ply, const 
         pvMove = state.prevPv.table[ply][0];
 
     // sort moves
-    advanceMoves adv = {
-        pvMove, INVALID_BITMOVE, kill.table[0][ply], kill.table[1][ply]};
+    advanceMoves adv = {pvMove, INVALID_BITMOVE, kill.table[0][ply], kill.table[1][ply]};
     sortMove(board, moves, nMoves, [&](BitMove move) { return scoreMove(board, move, adv); });
 
     for (int i = 0; i < nMoves; i++)

--- a/engine/src/search/Search.cpp
+++ b/engine/src/search/Search.cpp
@@ -58,7 +58,7 @@ int Search::scoreMove(const Board& board, const BitMove move, const advanceMoves
         score += KILLER_2_SCORE;
 
     // history heuristic
-    score += state.history.getHistory(board.player, move);
+    score += history.getHistory(board.player, move);
 
     return score;
 }
@@ -295,7 +295,7 @@ Search::chooseMove(Board& board, int depth, int alpha, int beta, int ply, const 
 
     // sort moves
     advanceMoves adv = {
-        pvMove, INVALID_BITMOVE, state.kill.table[0][ply], state.kill.table[1][ply]};
+        pvMove, INVALID_BITMOVE, kill.table[0][ply], kill.table[1][ply]};
     sortMove(board, moves, nMoves, [&](BitMove move) { return scoreMove(board, move, adv); });
 
     for (int i = 0; i < nMoves; i++)
@@ -410,7 +410,7 @@ int Search::negamax(Board& board, int depth, int alpha, int beta, int ply)
         pvMove = state.prevPv.table[ply][0];
 
     // Sort moves.
-    advanceMoves adv = {pvMove, ttMove, state.kill.table[0][ply], state.kill.table[1][ply]};
+    advanceMoves adv = {pvMove, ttMove, kill.table[0][ply], kill.table[1][ply]};
     sortMove(board, moves, nMoves, [&](BitMove move) { return scoreMove(board, move, adv); });
 
     // check checkmate / stalemate
@@ -491,8 +491,8 @@ int Search::negamax(Board& board, int depth, int alpha, int beta, int ply)
         {
             if (!undoState[ply].isCapture)
             {
-                state.kill.addKillerMove(move, ply);
-                state.history.updateHisroty(undoState[ply].player, move, depth);
+                kill.addKillerMove(move, ply);
+                history.updateHisroty(undoState[ply].player, move, depth);
             }
 
             if (i == 0)


### PR DESCRIPTION
- Found the main reason of #94. It is because of this commit: 6ad8f23bacc378923c7d58b911e564e843c91ef3.
- Adressed this issue in the next milestone: v0.4.
- Fixed some of the elo regressions. Please see [v0.3.0-alpha.3 v.s. 94-fix-elo-regression](http://127.0.0.1:8000/engine/optimization/v0.3.0_beta_optimization/20260601_234551_summary/)
- Won't change the engine's codes unless there is a bug waiting to be fixed, thus the next pre-release version will begin to use `v0.3.0-rc.x`. 

closes #94